### PR TITLE
fix(python): solc-select update

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pysha3==1.0.2
 python-dateutil==2.8.2
 pytz==2022.2.1
 six==1.16.0
-solc-select==1.0.3
+solc-select==1.0.4
 wcwidth==0.2.5
 typing-extensions==4.0.1
 z3-solver==4.11.2.0


### PR DESCRIPTION
solc-select needs to be updated due to a conflict that is caused by:  
The user requested solc-select==1.0.3  
crytic-compile 0.3.3 depends on solc-select>=v1.0.4